### PR TITLE
PORTF-1130 Changed build.sh GCC to 10.2.2020.11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,13 @@
 #!/bin/bash -eu
 
-PATH=/opt/arm/gcc-linaro-7.5.0-2019.12-i686_arm-linux-gnueabihf/bin:$PATH
+PATH=/opt/arm/gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf/bin:$PATH
 export INSTALL_MOD_PATH=$(pwd)/modules
 export ARCH=arm
-export CROSS_COMPILE=arm-linux-gnueabihf-
-
-#make savedefconfig
-#make menuconfig
+export CROSS_COMPILE=arm-none-linux-gnueabihf-
 
 make siklu_PCB277_V2_defconfig
+#make menuconfig
+#make savedefconfig
 make clean
 make zImage
 make modules


### PR DESCRIPTION
## Description
Changed the build.sh script to use GCC 10.2 instead of GCC 7.5

## Tests
 * Tested locally, only affects developers, not a kernel change

## References
JIRA: PORTF-1130