### PR TITLE
PORTF-2073: set pcf8523 capacitor in device tree

### DIFF
--- a/arch/arm/boot/dts/imx6ull-14x14-8012-siklu.dts
+++ b/arch/arm/boot/dts/imx6ull-14x14-8012-siklu.dts
@@ -247,7 +247,7 @@
 	rtc: pcf8523@68 {
 		compatible = "nxp,pcf8523";
 		reg = <0x68>;
-    quartz-load-femtofarads = <7000>;
+		quartz-load-femtofarads = <7000>;
 	};
 	tmp421@4c {
 		compatible = "ti,tmp421";

--- a/arch/arm/boot/dts/imx6ull-14x14-8012-siklu.dts
+++ b/arch/arm/boot/dts/imx6ull-14x14-8012-siklu.dts
@@ -247,6 +247,7 @@
 	rtc: pcf8523@68 {
 		compatible = "nxp,pcf8523";
 		reg = <0x68>;
+    quartz-load-femtofarads = <7000>;
 	};
 	tmp421@4c {
 		compatible = "ti,tmp421";

--- a/arch/arm/boot/dts/imx6ull-14x14-siklu.dts
+++ b/arch/arm/boot/dts/imx6ull-14x14-siklu.dts
@@ -210,8 +210,8 @@
 	rtc: pcf8523@68 {
 		compatible = "nxp,pcf8523";
 		reg = <0x68>;
-    quartz-load-femtofarads = <7000>;
-  };
+		quartz-load-femtofarads = <7000>;
+	};
 	tmp421@4c {
 		compatible = "ti,tmp421";
 		reg = <0x4c>;

--- a/arch/arm/boot/dts/imx6ull-14x14-siklu.dts
+++ b/arch/arm/boot/dts/imx6ull-14x14-siklu.dts
@@ -210,7 +210,8 @@
 	rtc: pcf8523@68 {
 		compatible = "nxp,pcf8523";
 		reg = <0x68>;
-	};
+    quartz-load-femtofarads = <7000>;
+  };
 	tmp421@4c {
 		compatible = "ti,tmp421";
 		reg = <0x4c>;


### PR DESCRIPTION
set rtc chip (pcf8523) capacitor to 7pF in device trees for 8020 and 8010
Reference: PORTF-2073